### PR TITLE
doc(fedora): Update `development-tools` install command

### DIFF
--- a/docs/BUILDING-FEDORA.md
+++ b/docs/BUILDING-FEDORA.md
@@ -7,7 +7,7 @@ Please follow the steps to install obs-backgroundremoval plugin on Fedora.
 First, you have to install the development tools:
 
 ```
-sudo dnf groupinstall "Development Tools"
+sudo dnf group install development-tools
 ```
 
 Then, make sure you have the dependencies of this plugin installed:


### PR DESCRIPTION
Since Fedora 41, `dnf` 5 is being delivered and the command for installing the `development-tools` has changed. 